### PR TITLE
Add missing commit after log deletion in DB cleanup

### DIFF
--- a/backend/ExecutionLogger.py
+++ b/backend/ExecutionLogger.py
@@ -56,6 +56,7 @@ class ExecutionLogger:
                             WHERE rn > ?
                         )
                     """, (MAX_ENTRIES,))
+                    conn.commit()
 
                 except Exception as e:
                     print(f"[ExecutionLogger] DB error: {e}")


### PR DESCRIPTION
Added a call to conn.commit() after deleting old log entries to ensure changes are saved to the database. This fixes potential issues where deletions were not persisted.